### PR TITLE
don't hang if all data already written

### DIFF
--- a/Ionic.Zlib/ParallelDeflateOutputStream.cs
+++ b/Ionic.Zlib/ParallelDeflateOutputStream.cs
@@ -880,8 +880,9 @@ namespace Ionic.Zlib
 
             if (emitting) return;
             emitting = true;
-            if (doAll || mustWait)
+            if ((doAll && (_lastCompressed != _lastFilled)) || mustWait) {
                 _newlyCompressedBlob.WaitOne();
+            }
 
             do
             {
@@ -968,7 +969,7 @@ namespace Ionic.Zlib
 
                 } while (nextToWrite >= 0);
 
-            } while (doAll && (_lastWritten != _latestCompressed));
+            } while (doAll && (_lastWritten != _lastFilled));
 
             emitting = false;
         }


### PR DESCRIPTION
should resolve #74.

_lastFilled is incremented when work is created
_latestCompressed is set by _Deflateone
_lastWritten is set by EmitPendingBuffers

All are monotonically incremented.

line 883: if _lastCompressed is equal to _lastFilled then all work is complete, waiting can hang
line 971: if _lastWritten==_lastCompressed, but there is still a worker thread running (ie _lastFilled>_lastCompressed) then the last chunk may not be written by the doAll flush

the change on 971 may slightly change the multi-thread behavior of the proc, if flush(true) is being called from a different thread to write. But in that case the entire current implementation is flaky anyway
